### PR TITLE
challenge should not be greater than n or the level won't be solvable

### DIFF
--- a/cryptography/run
+++ b/cryptography/run
@@ -240,7 +240,7 @@ def level11():
     show_hex("d", key.d)
     show_hex("n", key.n)
 
-    challenge = int.from_bytes(get_random_bytes(256), "little")
+    challenge = int.from_bytes(get_random_bytes(256), "little") % key.n
     show_hex("challenge", challenge)
 
     response = input_hex("response")


### PR DESCRIPTION
Since RSA keysize and challenge size are both 256 bytes, there was a 50% chance challenge would end up being greater than `key.n`, making the level unsolvable and forcing you to execute it multiple times until you get a solvable one. `% key.n` forces `challenge` to be less than `key.n`.