### PR TITLE
fix babyweb lv7: add rowid int check

### DIFF
--- a/web-security/run
+++ b/web-security/run
@@ -174,7 +174,8 @@ def level7():
         user = db.execute(f'SELECT rowid, * FROM users WHERE username = "{username}" AND password = "{password}"').fetchone()
         assert user, "Invalid `username` or `password`"
 
-        session["user"] = int(user["rowid"])
+        assert isinstance(user["rowid"], int), "Invalid rowid"
+        session["user"] = user["rowid"]
         return redirect(request.path)
 
     if session.get("user"):


### PR DESCRIPTION
- `user["rowid"]` should be an int type.
- In case when `user["rowid"]` is not an int, which can be done with SQLi, `int(user["rowid"])` caused a `ValueError` traceback error message.