### PR TITLE
Added .format() for syntax error in cmdi

### DIFF
--- a/web-security/cmdi-ls-pipe/server
+++ b/web-security/cmdi-ls-pipe/server
@@ -25,7 +25,7 @@ def challenge():
         <b>Output of: ls -l {directory}</b><br>
         <pre>{listing.replace("\n", "<br>")}</pre>
         </body></html>
-        """
+        """.format(directory=directory, listing=listing.replace("\n", "<br>"))
 
 app.secret_key = open("/flag").read().strip()
 app.run("challenge.localhost", int(os.environ.get("HTTP_PORT", 80)))

--- a/web-security/cmdi-ls-semicolon/server
+++ b/web-security/cmdi-ls-semicolon/server
@@ -25,7 +25,7 @@ def challenge():
         <b>Output of: ls -l {directory}</b><br>
         <pre>{listing.replace("\n", "<br>")}</pre>
         </body></html>
-        """
+        """.format(directory=directory, listing=listing.replace("\n", "<br>"))
 
 app.secret_key = open("/flag").read().strip()
 app.run("challenge.localhost", int(os.environ.get("HTTP_PORT", 80)))


### PR DESCRIPTION
Formatted the return object to mitigate the syntax error `f-string expression part cannot include a backslash`