### PR TITLE
[web-security] Tweak some descriptions to be less confusing for students

### DIFF
--- a/web-security/csrf-reflected-alert/DESCRIPTION.md
+++ b/web-security/csrf-reflected-alert/DESCRIPTION.md
@@ -4,7 +4,8 @@ Use the CSRF in this level to trigger a XSS and invoke an `alert("PWNED")` somew
 
 ----
 **HINT:**
-You will likely want to use JavaScript on your `http://hacker.localhost:1337` page to send `GET` request with `<script>` tags in a URL parameter.
-Be careful: your `<script>` tag will have the word `</script>` in a string (the URL parameter).
-This will string `</script>` will actually be parsed by your browser as the closing tag of your page's actual `<script>` tag, and all hell will break loose.
-I recommend dynamically building that string (e.g., `"</s"+"cript>") in the JavaScript that runs on `http://hacker.localhost:1337`.
+You will likely want to use JavaScript on your `http://hacker.localhost:1337` page to send a `GET` request with `<script>` tags in a URL parameter.
+Be careful: if you encode this JavaScript in your HTML, your `<script>` tag will have the word `</script>` in a string (the URL parameter).
+This string `</script>` will actually be parsed by your browser as the closing tag of your page's actual `<script>` tag, and all hell will break loose.
+
+If you encounter this error, I recommend dynamically building that string (e.g., `"</s"+"cript>"`) in the JavaScript that runs on `http://hacker.localhost:1337`.

--- a/web-security/level-1/DESCRIPTION.md
+++ b/web-security/level-1/DESCRIPTION.md
@@ -8,5 +8,5 @@ We recommend reading through its code to understand what it is doing and to find
 
 ----
 **HINT:**
-Make sure what you're trying to query is what is actually being received by the server! 
+If you're wondering why your solution isn't working, make sure what you're trying to query is what is actually being received by the server! 
 `curl -v [url]` can show you the exact bytes that curl is sending over.

--- a/web-security/level-11/DESCRIPTION.md
+++ b/web-security/level-11/DESCRIPTION.md
@@ -12,11 +12,11 @@ This style of _forging_ requests _across_ sites is called _Cross Site Request Fo
 Note that I said _almost_ nothing prevents this.
 The [Same-origin Policy](https://en.wikipedia.org/wiki/Same-origin_policy) was created in the 1990s, when the web was still young, to (try to) mitigate this problem.
 SOP prevents a site at one Origin (say, `http://www.hacker.com` or, in our case, `http://hacker.localhost:1337`) from interacting in certain security-critical ways with sites at other Origins (say, `http://www.asu.edu` or, in our case, `http://challenge.localhost/`).
-SOP prevents some common CSRF vectors (e.g., when using JavaScript to make a requests across Origins, cookies will not be sent!), but there are plenty of SOP-avoiding ways to, e.g., make `GET` requests with cookies intact (e.g., `<img>`s, `<iframe>`s, or even just full-on redirects).
+SOP prevents some common CSRF vectors (e.g., when using JavaScript to make a requests across Origins, cookies will not be sent!), but there are plenty of SOP-avoiding ways to, e.g., make `GET` requests with cookies intact (such as full-on redirects).
 
 In this level, pwnpost has fixed its XSS issues (at least for the `admin` user).
 You'll need to use CSRF to publish the flag post!
 The `/challenge/victim` of this level will log into pwnpost (`http://challenge.localhost/`) and will then visit an evil site that you can set up (`http://hacker.localhost:1337/`).
 `hacker.localhost` points to your local workspace, but you will need to set up a web server to serve an HTTP request on port 1337 yourself.
-Again, this can be done with `nc`.
+Again, this can be done with `nc` or with a python server (check out http.server!).
 Because these sites will have different Origins, SOP protections will apply, so be careful about how you forge the request!


### PR DESCRIPTION
## What?
Tweak some web-security descriptions to make them a little more helpful to students (and to reduce the likelihood of common misunderstandings).

@zardus 