### PR TITLE
Fix Cryptography level 1

### DIFF
--- a/cryptography/level-1/run
+++ b/cryptography/level-1/run
@@ -1,4 +1,5 @@
 #!/opt/pwn.college/python
 
 import base64
-print(f"The flag in base64: {base64.b64encode(open("/flag", "rb").read()).decode()}")
+flag = base64.b64encode(open("/flag", "rb").read()).decode()
+print(f"The flag in base64: {flag}")


### PR DESCRIPTION
Modified to fix the following error caused by the fstring:

```
File /challenge/run:4
    print(f"The flag in base64: {base64.b64encode(open("/flag", "rb").read()).decode()}")
                                                        ^
SyntaxError: f-string: unmatched '('
```