### PR TITLE
fix calling encode on bytes

### DIFF
--- a/cryptography/otp-tamper/worker
+++ b/cryptography/otp-tamper/worker
@@ -14,7 +14,7 @@ while line := sys.stdin.readline():
     cipher_len = min(len(data), len(key))
     plaintext = strxor(data[:cipher_len], key[:cipher_len])
 
-    print(f"Hex of plaintext: {plaintext.encode('latin1').hex()}")
+    print(f"Hex of plaintext: {plaintext.hex()}")
     print(f"Received command: {plaintext}")
     if plaintext == b"sleep":
         print("Sleeping!")


### PR DESCRIPTION
Original called .encode() on data which comes from bytes.fromhex(). Since this is already bytes, calling .encode() will always crash. 