### PR TITLE
Fix: Prevent the hidden byte spawning in the same position with the bomb byte in quest.py

### DIFF
--- a/reverse-engineering/cimg-quest-1/quest.py
+++ b/reverse-engineering/cimg-quest-1/quest.py
@@ -187,7 +187,7 @@ def game():
                 bomb_y = random.randrange(h)
             prev_hidden_x = hidden_x
             prev_hidden_y = hidden_y
-            while hidden_x == prev_hidden_x and hidden_y == prev_hidden_y:
+            while (hidden_x == prev_hidden_x and hidden_y == prev_hidden_y) or (hidden_x == bomb_x and hidden_y == bomb_y):
                 hidden_x = (bomb_x+random.randrange(w-1))%w
                 hidden_y = (bomb_y+random.randrange(h-1))%h
 

--- a/reverse-engineering/cimg-quest-2/quest.py
+++ b/reverse-engineering/cimg-quest-2/quest.py
@@ -194,7 +194,7 @@ def game():
                 bomb_y = random.randrange(h)
             prev_hidden_x = hidden_x
             prev_hidden_y = hidden_y
-            while hidden_x == prev_hidden_x and hidden_y == prev_hidden_y:
+            while (hidden_x == prev_hidden_x and hidden_y == prev_hidden_y) or (hidden_x == bomb_x and hidden_y == bomb_y):
                 hidden_x = (bomb_x+random.randrange(w-1))%w
                 hidden_y = (bomb_y+random.randrange(h-1))%h
 

--- a/reverse-engineering/cimg-quest-3/quest.py
+++ b/reverse-engineering/cimg-quest-3/quest.py
@@ -194,7 +194,7 @@ def game():
                 bomb_y = random.randrange(h)
             prev_hidden_x = hidden_x
             prev_hidden_y = hidden_y
-            while hidden_x == prev_hidden_x and hidden_y == prev_hidden_y:
+            while (hidden_x == prev_hidden_x and hidden_y == prev_hidden_y) or (hidden_x == bomb_x and hidden_y == bomb_y):
                 hidden_x = (bomb_x+random.randrange(w-1))%w
                 hidden_y = (bomb_y+random.randrange(h-1))%h
 


### PR DESCRIPTION
The current quest.py using randrange(w - 1) and randrange(h - 1) to determine the offset from the hidden byte to the bomb but it have a chance to be 0 on both offset, the bomb overlay the hidden byte which make it impossible for the player to continue. 

To prevent this I modified the conditions of the while loop so that the hidden bytes cannot spawn at the same position with the bomb.